### PR TITLE
Inreased nginx file upload from 32MB to 40MB

### DIFF
--- a/openshift/drupal/nginx.conf
+++ b/openshift/drupal/nginx.conf
@@ -38,7 +38,7 @@ http {
   # length is greater than this size, then the client receives the HTTP
   # error code 413. Set to 0 to disable. Default is '1m'.
   client_body_buffer_size 32M;
-  client_max_body_size 32M;
+  client_max_body_size 40M;
 
   # Sendfile copies data between one FD and other from within the kernel,
   # which is more efficient than read() + write(). Default is off.


### PR DESCRIPTION
This was requested for Asuntotuotanto project, though it will change for all drupal projects but the the size increase is not big.