### PR TITLE
UHF-6968: Deny access to update.php and install.php files

### DIFF
--- a/openshift/drupal/drupal.conf
+++ b/openshift/drupal/drupal.conf
@@ -65,6 +65,11 @@ server {
         return 404;
     }
 
+    # Deny access to update.php and core/install.php files.
+    location ~ 'update\.php$|core/install\.php' {
+        deny all;
+    }
+
     # In Drupal 8, we must also match new paths where the '.php' appears in
     # the middle, such as update.php/selection. The rule we use is strict,
     # and only allows this pattern with the update.php front controller.

--- a/openshift/drupal/drupal.conf
+++ b/openshift/drupal/drupal.conf
@@ -68,6 +68,12 @@ server {
     # Deny access to update.php and core/install.php files.
     location ~ 'update\.php$|core/install\.php' {
         deny all;
+        return 404;
+    }
+
+    location ~ \.(engine|inc|info|install|make|mk|module|profile|test|po|sh|yml|yaml|.*sql|theme|tpl(\.php)?|xtmpl)$|^(\..*|Entries.*|Repository|Root|Tag|Template)$ {
+        deny all;
+        return 404;
     }
 
     # In Drupal 8, we must also match new paths where the '.php' appears in


### PR DESCRIPTION
**To test**
- Read changes. Could this cause any potential issues?
- Any other files that should be blocked? Blocking all PHP files other than index.php might require more thought as it might cause unforeseen issues and the current situation is quite secure as it is (php files inside vendor and files are already blocked).
- You can test this locally by adding the following code into `/etc/nginx/conf.d/custom.locations`  and `/etc/nginx/conf.d/default.conf` on any instance and running `sudo nginx -s reload`:
- Custom.locations:
```
location ~ 'update\.php$|core/install\.php' {
  deny all;
}
location ~ \.(engine|inc|info|install|make|mk|module|profile|test|po|sh|yml|yaml|.*sql|theme|tpl(\.php)?|xtmpl)$|^(\..*|Entries.*|Repository|Root|Tag|Template)$ {
  deny all;
  return 404;
}
```
- Now if you try to load /update.php or /core/install.php you should get a 403 error.