### PR TITLE
Revert disabling garbage collector as this is being used by migration…

### DIFF
--- a/openshift/drupal/Dockerfile
+++ b/openshift/drupal/Dockerfile
@@ -227,9 +227,7 @@ RUN { \
 
 # Override memory limit and upload max filesize and post max size
 # to enable bigger uploads
-# New relic triggers garbage collector which adds extra time on the request.
 RUN { \
-        echo 'zend.enable_gc=Off'; \
 		echo 'memory_limit=512M'; \
 		echo 'upload_max_filesize=32M'; \
 		echo 'post_max_size=32M'; \


### PR DESCRIPTION
… to free up memory when large migrations.