### PR TITLE
PLATTA-4843 image styles with + in their names fails

### DIFF
--- a/openshift/drupal/drupal.conf
+++ b/openshift/drupal/drupal.conf
@@ -123,11 +123,14 @@ server {
   # Support for the helfi_proxy module
   # https://github.com/City-of-Helsinki/drupal-module-helfi-proxy
   location ~ ^/(?:.*)-assets/(.*)$ {
+    rewrite ^ $request_uri;
+    rewrite ^/(?:.*)-assets/(.*)$ $1 break;
+    return 400;
     proxy_redirect off;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass http://127.0.0.1:8080/$1$is_args$args;
+    proxy_pass http://127.0.0.1:8080/$uri;
   }
 }


### PR DESCRIPTION
the reason is that during proxy pass, the url gets escaped, passing + to the proxy pass which translates as space
so Drupal would search for image with space in the name instead of +
check this before review - https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4843?focusedCommentId=89576

