### PR TITLE
UHF-9154: Override /etc/profile

### DIFF
--- a/openshift/drupal/files/etc/profile
+++ b/openshift/drupal/files/etc/profile
@@ -1,0 +1,34 @@
+export PATH="${PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+export PAGER=less
+umask 022
+
+# use nicer PS1 for bash and busybox ash
+if [ -n "$BASH_VERSION" -o "$BB_ASH_VERSION" ]; then
+        PS1='\h:\w\$ '
+# use nicer PS1 for zsh
+elif [ -n "$ZSH_VERSION" ]; then
+        PS1='%m:%~%# '
+# set up fallback default PS1
+else
+        : "${HOSTNAME:=$(hostname)}"
+        PS1='${HOSTNAME%%.*}:$PWD'
+        [ "$(id -u)" -eq 0 ] && PS1="${PS1}# " || PS1="${PS1}\$ "
+fi
+
+if [ -n "$BASH_VERSION" ] && [ "$BASH" != "/bin/sh" ]; then
+        # if we're bash (and not /bin/sh bash), also source the bashrc
+        # by default, bash sources the bashrc for non-login,
+        # and only /etc/profile on login (-l). so, make it do both on login.
+        # this ensures that login-shell bash (e.g. -bash or bash -l) still sources the
+        # system bashrc, which e.g. loads bash-completion
+        . /etc/bash/bashrc
+fi
+
+for script in /etc/profile.d/*.sh ; do
+        if [ -r "$script" ] ; then
+                . "$script"
+        fi
+done
+unset script
+export PS1="[${APP_ENV:-env}] \[\e[1;31m\][${HOSTNAME:-hostname}] \[\e[1;33m\]\w\[\e[0m\] $ "


### PR DESCRIPTION
Looks like Alpine 3.18 version overrides the $PATH variable in /etc/profile now: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/46341/diffs

We define the $PATH variable in our Dockerfile and the /etc/profile is "sourced" when launching an interactive shell, meaning the existing PATH definition will always be overridden.