### PR TITLE
Add x-robots-tag: noindex, nofollow header to all test/staging environments

### DIFF
--- a/openshift/drupal/Dockerfile
+++ b/openshift/drupal/Dockerfile
@@ -168,23 +168,23 @@ ARG PHP_SHORT_VERSION
 # see https://secure.php.net/manual/en/opcache.installation.php
 # we set enable_file_override as files won't change while container is up.
 RUN { \
-		echo 'opcache.memory_consumption=512'; \
-		echo 'opcache.interned_strings_buffer=64'; \
-		echo 'opcache.max_accelerated_files=30000'; \
-        echo 'opcache.enable_file_override=1'; \
-		echo 'opcache.validate_timestamps=0'; \
-	} > /etc/php${PHP_SHORT_VERSION}/conf.d/opcache-recommended.ini
+  echo 'opcache.memory_consumption=512'; \
+  echo 'opcache.interned_strings_buffer=64'; \
+  echo 'opcache.max_accelerated_files=30000'; \
+  echo 'opcache.enable_file_override=1'; \
+  echo 'opcache.validate_timestamps=0'; \
+} > /etc/php${PHP_SHORT_VERSION}/conf.d/opcache-recommended.ini
 
 # Override memory limit and upload max filesize and post max size
 # to enable bigger uploads
 RUN { \
-		echo 'memory_limit=512M'; \
-		echo 'upload_max_filesize=32M'; \
-		echo 'post_max_size=32M'; \
-    echo 'max_execution_time=180'; \
-    echo 'realpath_cache_size=8M'; \
-    echo 'apc.shm_size=64M'; \
-	} > /etc/php${PHP_SHORT_VERSION}/conf.d/php-overrides.ini
+  echo 'memory_limit=512M'; \
+  echo 'upload_max_filesize=32M'; \
+  echo 'post_max_size=32M'; \
+  echo 'max_execution_time=180'; \
+  echo 'realpath_cache_size=8M'; \
+  echo 'apc.shm_size=64M'; \
+} > /etc/php${PHP_SHORT_VERSION}/conf.d/php-overrides.ini
 
 # Override default fpm pool conf to run nginx and php-fpm as same user.
 COPY php-fpm-pool.conf /etc/php${PHP_SHORT_VERSION}/php-fpm.d/www.conf

--- a/openshift/drupal/README.md
+++ b/openshift/drupal/README.md
@@ -23,7 +23,8 @@ Testing environment uses `*-dev` images by default and it's highly recommended t
 - Build the image: `make build-php81-dev` (change `php81` to whatever is your actual PHP version)
 - Find the image ID of latest `docker images ghcr.io/city-of-helsinki/drupal-docker-base` image and copy the image ID
 - Change project's `DRUPAL_IMAGE` (in `.env` file) to image ID from previous step
-- Change app container's volume from `/app` to `/var/www/html` (in `docker-compose.yml` file)
+- Add `SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"` to `app` service's environments in `compose.yaml`
+- Change app container's volume from `/app` to `/var/www/html` (in `compose.yaml` file)
 - Re/start containers: `docker-compose stop && docker compose up -d`
 
 ### Building

--- a/openshift/drupal/files/entrypoints/99-nginx.sh
+++ b/openshift/drupal/files/entrypoints/99-nginx.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if echo "$APP_ENV" | grep -Eq '(local|dev|development|test|testing|stage|staging)'; then
+  echo 'add_header  X-Robots-Tag "noindex, nofollow";' >> /etc/nginx/conf.d/global-headers
+fi
+
 echo "Start up Nginx..."
 
 nginx -g 'daemon off;'

--- a/openshift/drupal/files/etc/nginx/http.d/default.conf
+++ b/openshift/drupal/files/etc/nginx/http.d/default.conf
@@ -23,6 +23,8 @@ server {
     proxy_pass http://127.0.0.1:8080/$1$is_args$args;
   }
 
+  include conf.d/global-headers;
+
   # Allow locations to be added without overriding the whole conf.
   include conf.d/custom.locations;
 


### PR DESCRIPTION
## How to install

- Build the OpenShift Drupal base image and test it on any project. See  [Testing production image locally](https://github.com/City-of-Helsinki/drupal-docker-images/blob/684d3f0889c42db3efb0f175c348205a5e876f0d/openshift/drupal/README.md#testing-production-image-locally) for documentation

## How to test

- Make sure helfi proxy module (or platform config) does not add robots header already
- Run random requests against the site and make sure x-robots-tag header is present