### PR TITLE
Allow db sync with oc login --web

### DIFF
--- a/local/oc/Dockerfile
+++ b/local/oc/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.20
 
+COPY files/ /
+
 ENV OC_TAG=openshift-clients-4.17.0-202409111134
 RUN \
   apk add --no-cache --virtual .build-deps \
@@ -16,3 +18,5 @@ RUN \
   rm -rf /oc-code /root/go /root/.cache; \
   apk del .build-deps ; \
   oc version
+
+ENTRYPOINT /usr/local/bin/db-sync

--- a/local/oc/files/usr/local/bin/db-sync
+++ b/local/oc/files/usr/local/bin/db-sync
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -n "$OC_PROJECT_NAME" ]; then
+  echo "OC_PROJECT_NAME not set."
+  exit 1;
+fi
+
+oc login --server=https://api.arodevtest.hel.fi:6443 --web --callback-port 8280
+oc project ${OC_PROJECT_NAME}
+
+OC_POD_NAME=$(oc get pods -o name | grep drupal-cron | grep -v deploy)
+
+if [ ! -n "$OC_POD_NAME" ]; then
+  echo "Failed to parse pod name."
+  exit 1
+fi
+
+oc rsh $OC_POD_NAME rm -f /tmp/dump.sql.gz
+oc rsh $OC_POD_NAME drush sql:dump --structure-tables-key=common \
+  --extra-dump='--no-tablespaces --hex-blob' \
+  --result-file=/tmp/dump.sql \
+  --gzip
+
+oc rsync $OC_POD_NAME:/tmp/dump.sql.gz /app

--- a/local/oc/files/usr/local/bin/xdg-open
+++ b/local/oc/files/usr/local/bin/xdg-open
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# no-op
+# oc login --web wants to open a web browser, but there is
+# no simple way to do that from a docker container.


### PR DESCRIPTION
## How to test

- Build image `make -C local/oc`
- Test db sync `docker run --network host -it -e OC_PROJECT_NAME=hki-kanslia-liikenne-test eab0aab92a133bf4d78f47db69218ccafec260c36ee6030421e8a3850f7ebc0f` (or whatever image hash you get, check from make output).