### PR TITLE
UHF-11475: Add DRUSH_ALLOW_XDEBUG=1 environment variable

### DIFF
--- a/local/drupal/Dockerfile
+++ b/local/drupal/Dockerfile
@@ -11,6 +11,7 @@ ENV DRUPAL_DB_NAME=drupal \
 ENV SIMPLETEST_DB="mysql://${DRUPAL_DB_USER}:${DRUPAL_DB_PASS}@${DRUPAL_DB_HOST}:${DRUPAL_DB_PORT}/${DRUPAL_DB_NAME}"
 ENV SIMPLETEST_BASE_URL=https://app
 ENV COMPOSER_HOME=/tmp/.composer
+ENV DRUSH_ALLOW_XDEBUG=1
 
 RUN apk add --no-cache \
   --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \


### PR DESCRIPTION
Drush v13 disables xdebug by default to improve performance. For DevEx, this forces xdebug to be enabled for drush on our development docker images.