### PR TITLE
Add drush.yml

### DIFF
--- a/local/drupal/Dockerfile
+++ b/local/drupal/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod +x /entrypoints/* \
     /usr/local/bin/drush
 
 COPY files/etc/nginx /etc/nginx
+COPY files/etc/drush /etc/drush
 
 WORKDIR /app
 

--- a/local/drupal/files/etc/drush/drush.yml
+++ b/local/drupal/files/etc/drush/drush.yml
@@ -1,0 +1,13 @@
+command:
+  # MariaDB cli requires valid certificate by default,
+  # which we don't have for local environment.
+  sql:
+    query:
+      options:
+        extra: "--skip-ssl"
+    cli:
+      options:
+        extra: "--skip-ssl"
+    dump:
+      options:
+        extra-dump: "--skip-ssl"


### PR DESCRIPTION
## How to test

- `cd local/drupal` and `docker buildx build --no-cache --pull --target=final -t ghcr.io/city-of-helsinki/drupal-web:8.3 --build-arg PHP_VERSION=8.3 --build-arg PHP_SHORT_VERSION=83 ./ --load`
- Get image ID: `docker images ghcr.io/city-of-helsinki/drupal-web:8.3 --format json | jq -r .ID`.
- In any project, change `DRUPAL_IMAGE=<image id>` in `.env` file.
- Test that drush commands work: `make up shell`
  - [ ] `drush sql:cli` works
  - [ ] `drush sql:query` works
  - [ ] `drush sql:dump` works